### PR TITLE
Enable setting of a bootstrap id at runtime

### DIFF
--- a/backend/lores-node-axum/src/api/node_steward_api/routes/network.rs
+++ b/backend/lores-node-axum/src/api/node_steward_api/routes/network.rs
@@ -11,6 +11,7 @@ use crate::{
     panda_comms::{build_public_key_from_hex, PandaContainer},
     DatabaseState,
 };
+use lores_p2panda::RelayUrl;
 
 pub fn router() -> OpenApiRouter {
     OpenApiRouter::new()
@@ -53,7 +54,10 @@ async fn add_bootstrap_node(
     }
 
     // Add the bootstrap node to the current PandaContainer
-    if let Err(e) = panda_container.add_bootstrap_node(&payload.node_id).await {
+    if let Err(e) = panda_container
+        .add_bootstrap_node(&payload.node_id, None)
+        .await
+    {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to add bootstrap node: {}", e),

--- a/backend/lores-node-axum/src/panda_comms/panda_container.rs
+++ b/backend/lores-node-axum/src/panda_comms/panda_container.rs
@@ -11,6 +11,7 @@ use lores_p2panda::{
         SubscriptionError,
     },
     topic_status::ConnectionStatus,
+    RelayUrl,
 };
 
 use crate::api::auth_api::auth_backend::User;
@@ -355,15 +356,31 @@ impl PandaContainer {
         Some(NodeStatusSnapshot { topics })
     }
 
-    /// Validates the node ID and saves it to params. The new peer will be
-    /// discovered on the next node restart via the saved config; the high-level
-    /// p2panda API does not support adding bootstrap nodes at runtime.
+    /// Validates the node ID, inserts the bootstrap peer into the running node
+    /// when it is already started, and saves it to params so it will be used on
+    /// the next restart as well.
     pub async fn add_bootstrap_node(
         &self,
         bootstrap_node_id_hex: &str,
+        relay_url: Option<RelayUrl>,
     ) -> Result<(), anyhow::Error> {
-        build_public_key_from_hex(bootstrap_node_id_hex)
+        let node_id = build_public_key_from_hex(bootstrap_node_id_hex)
             .map_err(|e| anyhow::anyhow!("Invalid bootstrap node ID: {}", e))?;
+
+        {
+            let node_lock = self.node.lock().await;
+            if let Some(node) = node_lock.as_ref() {
+                node.insert_bootstrap(node_id, relay_url).await.map_err(|e| {
+                    anyhow::anyhow!("Failed to insert bootstrap node at runtime: {}", e)
+                })?;
+            }
+        }
+
+        let mut params_lock = self.params.lock().await;
+        if !params_lock.bootstrap_node_ids.contains(&node_id) {
+            params_lock.bootstrap_node_ids.push(node_id);
+        }
+
         Ok(())
     }
 }

--- a/backend/lores-p2panda/src/lib.rs
+++ b/backend/lores-p2panda/src/lib.rs
@@ -13,3 +13,4 @@ pub use topic_status::{ConnectionStatus, TopicStatus};
 
 pub use p2panda_core;
 pub use p2panda_core::Topic;
+pub use p2panda_net::iroh_endpoint::RelayUrl;

--- a/backend/lores-p2panda/src/panda_node.rs
+++ b/backend/lores-p2panda/src/panda_node.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use p2panda::Node;
+use p2panda::NodeId;
+use p2panda::network::NetworkError;
 use p2panda::node::SpawnError;
 use p2panda::streams::{PublishError, StreamEvent, StreamFrom, StreamPublisher};
 use p2panda_core::{Hash, SigningKey, Topic, VerifyingKey};
@@ -191,6 +193,18 @@ impl PandaNode {
     /// Returns all registered region IDs.
     pub async fn get_regions(&self) -> Vec<RegionId> {
         self.regions.read().await.iter().cloned().collect()
+    }
+
+    /// Insert a bootstrap node at runtime.
+    pub async fn insert_bootstrap(
+        &self,
+        node_id: NodeId,
+        relay_url: Option<RelayUrl>,
+    ) -> Result<(), NetworkError> {
+        let relay_url = relay_url.unwrap_or_else(|| DEFAULT_IROH_RELAY_URL.clone());
+        let network = self.network.read().await;
+
+        network.insert_bootstrap(node_id, relay_url).await
     }
 
     /// Creates a new `StreamFrom::Start` stream for `topic_id` and forwards every


### PR DESCRIPTION
This capability nearly existed, but it just wasn't wired up. Instead, the bootstrap ID was only being added to the config to be applied at startup. 

Now, we send it through and apply it to the running panda node. At the moment, we don't supply a relay URL, and so the default one is applied.