### PR TITLE
Supply region and node info to apps

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3105,7 +3105,9 @@ dependencies = [
 name = "lores-p2panda-client"
 version = "0.3.1"
 dependencies = [
+ "hex",
  "prost",
+ "serde",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/backend/lores-app-node/Cargo.toml
+++ b/backend/lores-app-node/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lores-p2panda-client = { path = "../lores-p2panda-client" }
+lores-p2panda-client = { path = "../lores-p2panda-client", features = ["serde"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/backend/lores-app-node/src/consumer.rs
+++ b/backend/lores-app-node/src/consumer.rs
@@ -2,7 +2,7 @@ use futures::StreamExt;
 use tokio::sync::broadcast;
 
 use crate::stores::{OperationStream, RawOperationEvent, StoreError};
-use crate::types::{AppNodeOperation, LoResNodeId, LoResOperationId};
+use crate::types::{AppNodeOperation, NodeId, OperationId};
 
 /// Deserializes raw operation payloads from a stream and broadcasts them to
 /// all subscribers of the event channel.
@@ -55,8 +55,8 @@ impl<Op: Clone + Send + 'static> OperationConsumer<Op> {
                         let _ = self.event_tx.send(AppNodeOperation {
                             op,
                             local_operation_id: None,
-                            author_node_id: author.map(LoResNodeId),
-                            panda_operation_id: operation_id.map(LoResOperationId),
+                            author_node_id: author.map(NodeId),
+                            panda_operation_id: operation_id.map(OperationId),
                             timestamp,
                         });
                         count += 1;

--- a/backend/lores-app-node/src/lib.rs
+++ b/backend/lores-app-node/src/lib.rs
@@ -9,4 +9,5 @@ mod types;
 pub use node::{AppNode, NodeError};
 pub use projection::ProjectionDb;
 pub use stores::StoreError;
+pub use lores_p2panda_client::{GetNodeError, NodeInfo};
 pub use types::{AppNodeOperation, NodeEvent, NodeId, OperationId, RegionId, RegionInfo};

--- a/backend/lores-app-node/src/lib.rs
+++ b/backend/lores-app-node/src/lib.rs
@@ -9,4 +9,4 @@ mod types;
 pub use node::{AppNode, NodeError};
 pub use projection::ProjectionDb;
 pub use stores::StoreError;
-pub use types::{AppNodeOperation, LoResNodeId, LoResOperationId, NodeEvent};
+pub use types::{AppNodeOperation, NodeEvent, NodeId, OperationId, RegionId, RegionInfo};

--- a/backend/lores-app-node/src/lib.rs
+++ b/backend/lores-app-node/src/lib.rs
@@ -6,8 +6,8 @@ mod stores;
 mod subscription;
 mod types;
 
+pub use lores_p2panda_client::{GetNodeError, NodeInfo};
 pub use node::{AppNode, NodeError};
 pub use projection::ProjectionDb;
 pub use stores::StoreError;
-pub use lores_p2panda_client::{GetNodeError, NodeInfo};
 pub use types::{AppNodeOperation, NodeEvent, NodeId, OperationId, RegionId, RegionInfo};

--- a/backend/lores-app-node/src/node.rs
+++ b/backend/lores-app-node/src/node.rs
@@ -154,6 +154,20 @@ impl<Op: Clone + Serialize + Send + 'static> AppNode<Op> {
         self.node_event_tx.subscribe()
     }
 
+    /// Fetch information about a node in the same region.
+    pub async fn node_info(&self, node_id: impl Into<String>) -> Result<lores_p2panda_client::NodeInfo, lores_p2panda_client::GetNodeError> {
+        let client = self.panda_client.as_ref().ok_or_else(|| {
+            lores_p2panda_client::GetNodeError::Other(lores_p2panda_client::PandaError::Rpc(
+                tonic::Status::failed_precondition("node_info requires a gRPC connection"),
+            ))
+        })?;
+        let mut guard = client.lock().await;
+        let client: &mut lores_p2panda_client::PandaClient = &mut *guard;
+        client
+            .get_node(&self.app_id, &self.instance_id, node_id.into())
+            .await
+    }
+
     /// Replay all locally-stored operations, broadcasting each through the
     /// event channel.
     pub async fn replay(&self) -> Result<(), StoreError>

--- a/backend/lores-app-node/src/node.rs
+++ b/backend/lores-app-node/src/node.rs
@@ -209,6 +209,7 @@ impl<Op: Clone + Serialize + Send + 'static> AppNode<Op> {
             self.error_tx.clone(),
             self.node_event_tx.clone(),
             self.panda_client.clone(),
+            self.app_id.clone(),
             self.instance_id.clone(),
         )
         .run()

--- a/backend/lores-app-node/src/node.rs
+++ b/backend/lores-app-node/src/node.rs
@@ -155,17 +155,18 @@ impl<Op: Clone + Serialize + Send + 'static> AppNode<Op> {
     }
 
     /// Fetch information about a node in the same region.
-    pub async fn node_info(&self, node_id: impl Into<String>) -> Result<lores_p2panda_client::NodeInfo, lores_p2panda_client::GetNodeError> {
+    pub async fn node_info(
+        &self,
+        node_id: impl Into<String>,
+    ) -> Result<lores_p2panda_client::NodeInfo, lores_p2panda_client::GetNodeError> {
         let client = self.panda_client.as_ref().ok_or_else(|| {
-            lores_p2panda_client::GetNodeError::Other(lores_p2panda_client::PandaError::Rpc(
-                tonic::Status::failed_precondition("node_info requires a gRPC connection"),
-            ))
+            lores_p2panda_client::GetNodeError::Other(lores_p2panda_client::PandaError::Rpc(tonic::Status::failed_precondition(
+                "node_info requires a gRPC connection",
+            )))
         })?;
         let mut guard = client.lock().await;
         let client: &mut lores_p2panda_client::PandaClient = &mut *guard;
-        client
-            .get_node(&self.app_id, &self.instance_id, node_id.into())
-            .await
+        client.get_node(&self.app_id, &self.instance_id, node_id.into()).await
     }
 
     /// Replay all locally-stored operations, broadcasting each through the

--- a/backend/lores-app-node/src/stores/grpc.rs
+++ b/backend/lores-app-node/src/stores/grpc.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     stores::{OperationStore, OperationStream, RawOperationEvent, StoreError, StorePublishResult},
-    LoResNodeId, LoResOperationId,
+    NodeId, OperationId,
 };
 
 impl From<PandaError> for StoreError {
@@ -52,8 +52,8 @@ impl OperationStore for GrpcOperationStore {
                 .await
                 .map_err(StoreError::from)?;
             Ok(StorePublishResult {
-                operation_id: operation_id.into_non_empty().map(LoResOperationId),
-                node_id: node_id.into_non_empty().map(LoResNodeId),
+                operation_id: operation_id.into_non_empty().map(OperationId),
+                node_id: node_id.into_non_empty().map(NodeId),
             })
         })
     }

--- a/backend/lores-app-node/src/stores/mod.rs
+++ b/backend/lores-app-node/src/stores/mod.rs
@@ -3,14 +3,14 @@ use std::pin::Pin;
 
 use futures::Stream;
 
-use crate::types::{LoResNodeId, LoResOperationId};
+use crate::types::{NodeId, OperationId};
 
 /// Result returned by [`OperationStore::publish`].
 pub(crate) struct StorePublishResult {
     /// p2panda operation hash, if the backend can provide it synchronously.
-    pub operation_id: Option<LoResOperationId>,
+    pub operation_id: Option<OperationId>,
     /// Identity of the node that persisted the operation, if known.
-    pub node_id: Option<LoResNodeId>,
+    pub node_id: Option<NodeId>,
 }
 
 /// Error returned by [`OperationStore`] methods.

--- a/backend/lores-app-node/src/subscription.rs
+++ b/backend/lores-app-node/src/subscription.rs
@@ -17,6 +17,7 @@ pub(crate) struct LiveSubscription<Op> {
     error_tx: watch::Sender<Option<NodeError>>,
     node_event_tx: broadcast::Sender<NodeEvent>,
     panda_client: Option<Arc<Mutex<PandaClient>>>,
+    app_id: String,
     instance_id: String,
 }
 
@@ -27,6 +28,7 @@ impl<Op: Clone + Send + 'static> LiveSubscription<Op> {
         error_tx: watch::Sender<Option<NodeError>>,
         node_event_tx: broadcast::Sender<NodeEvent>,
         panda_client: Option<Arc<Mutex<PandaClient>>>,
+        app_id: String,
         instance_id: String,
     ) -> Self {
         Self {
@@ -35,6 +37,7 @@ impl<Op: Clone + Send + 'static> LiveSubscription<Op> {
             error_tx,
             node_event_tx,
             panda_client,
+            app_id,
             instance_id,
         }
     }
@@ -86,10 +89,11 @@ impl<Op: Clone + Send + 'static> LiveSubscription<Op> {
         let Some(client) = &self.panda_client else {
             return;
         };
-        match client.lock().await.info(&self.instance_id).await {
-            Ok(node_id) => {
+        match client.lock().await.info(&self.app_id, &self.instance_id).await {
+            Ok(info) => {
                 let _ = self.node_event_tx.send(NodeEvent::ServerConnected {
-                    node_id: crate::types::LoResNodeId(node_id.0),
+                    node_id: info.node_id,
+                    region: crate::types::RegionInfo { region_id: info.region_id },
                 });
             }
             Err(e) => tracing::warn!("Failed to fetch server info: {e}"),

--- a/backend/lores-app-node/src/subscription.rs
+++ b/backend/lores-app-node/src/subscription.rs
@@ -93,7 +93,11 @@ impl<Op: Clone + Send + 'static> LiveSubscription<Op> {
             Ok(info) => {
                 let _ = self.node_event_tx.send(NodeEvent::ServerConnected {
                     node_id: info.node_id,
-                    region: crate::types::RegionInfo { region_id: info.region_id },
+                    region: crate::types::RegionInfo {
+                        region_id: info.region.region_id,
+                        slug: info.region.slug,
+                        name: info.region.name,
+                    },
                 });
             }
             Err(e) => tracing::warn!("Failed to fetch server info: {e}"),

--- a/backend/lores-app-node/src/types.rs
+++ b/backend/lores-app-node/src/types.rs
@@ -2,35 +2,16 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use uuid::Uuid;
 
-/// 32-byte p2panda public key identifying a remote author.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct LoResNodeId(pub Vec<u8>);
+pub use lores_p2panda_client::{NodeId, OperationId, RegionId};
 
-impl LoResNodeId {
-    pub fn to_hex(&self) -> String {
-        hex::encode(&self.0)
-    }
+#[derive(Clone, Debug)]
+pub struct RegionInfo {
+    pub region_id: RegionId,
 }
 
-impl fmt::Debug for LoResNodeId {
+impl fmt::Display for RegionInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LoResNodeId({})", self.to_hex())
-    }
-}
-
-/// 32-byte p2panda operation hash.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct LoResOperationId(pub Vec<u8>);
-
-impl LoResOperationId {
-    pub fn to_hex(&self) -> String {
-        hex::encode(&self.0)
-    }
-}
-
-impl fmt::Debug for LoResOperationId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LoResOperationId({})", self.to_hex())
+        fmt::Display::fmt(&self.region_id, f)
     }
 }
 
@@ -40,14 +21,14 @@ pub struct AppNodeOperation<Op> {
     /// Stable local identity assigned at publish time, before any network round-trip.
     pub local_operation_id: Option<Uuid>,
     /// 32-byte p2panda operation hash. `None` for locally-published operations.
-    pub panda_operation_id: Option<LoResOperationId>,
+    pub panda_operation_id: Option<OperationId>,
     /// p2panda public key of the node that authored the operation.
-    pub author_node_id: Option<LoResNodeId>,
+    pub author_node_id: Option<NodeId>,
     pub timestamp: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
 pub enum NodeEvent {
-    ServerConnected { node_id: LoResNodeId },
+    ServerConnected { node_id: NodeId, region: RegionInfo },
     ServerDisconnected,
 }

--- a/backend/lores-app-node/src/types.rs
+++ b/backend/lores-app-node/src/types.rs
@@ -7,6 +7,8 @@ pub use lores_p2panda_client::{NodeId, OperationId, RegionId};
 #[derive(Clone, Debug)]
 pub struct RegionInfo {
     pub region_id: RegionId,
+    pub slug: Option<String>,
+    pub name: Option<String>,
 }
 
 impl fmt::Display for RegionInfo {

--- a/backend/lores-node-axum/src/local_apps/region_resolver.rs
+++ b/backend/lores-node-axum/src/local_apps/region_resolver.rs
@@ -1,20 +1,21 @@
-use lores_p2panda_server::{AppInstanceIds, ResolveRegionId, ResolveRegionIdError};
+use lores_p2panda_server::{AppInstanceIds, ResolveRegionId, ResolveRegionIdError, ResolvedRegion};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use tracing::warn;
 
 use crate::data::node_data::local_apps_repo::LocalAppsRepo;
+use crate::data::projections_read::regions::RegionsReadRepo;
 
 /// Returns a [`lores_p2panda_server::ResolveRegionId`] callback that looks up
 /// the `bound_to_region_id` for a given app/instance pair from the node_data
-/// database.  Returns `Status::not_found` if no binding exists and
-/// `Status::internal` if the stored value is malformed.
-pub fn make_region_resolver(pool: SqlitePool) -> ResolveRegionId {
+/// database, then enriches with slug/name from the projections database.
+pub fn make_region_resolver(node_data_pool: SqlitePool, projections_pool: SqlitePool) -> ResolveRegionId {
     Arc::new(move |ids: AppInstanceIds| {
-        let pool = pool.clone();
+        let node_data_pool = node_data_pool.clone();
+        let projections_pool = projections_pool.clone();
         Box::pin(async move {
             let row = LocalAppsRepo::init()
-                .find(&pool, &ids.app_id, &Some(ids.instance_id.clone()))
+                .find(&node_data_pool, &ids.app_id, &Some(ids.instance_id.clone()))
                 .await
                 .map_err(|e| {
                     warn!("[region_resolver] database error: {e}");
@@ -23,12 +24,26 @@ pub fn make_region_resolver(pool: SqlitePool) -> ResolveRegionId {
 
             let region_id_hex = row.and_then(|app| app.bound_to_region_id).ok_or(ResolveRegionIdError::NotFound)?;
 
-            lores_p2panda::RegionId::from_hex(&region_id_hex).map_err(|_| {
+            let region_id = lores_p2panda::RegionId::from_hex(&region_id_hex).map_err(|_| {
                 warn!(
                     "[region_resolver] invalid region_id hex in database for app '{}' instance '{}': '{}'",
                     ids.app_id, ids.instance_id, region_id_hex
                 );
                 ResolveRegionIdError::Internal
+            })?;
+
+            let region = RegionsReadRepo::init()
+                .find(&projections_pool, &region_id_hex)
+                .await
+                .map_err(|e| {
+                    warn!("[region_resolver] projections database error: {e}");
+                    ResolveRegionIdError::Internal
+                })?;
+
+            Ok(ResolvedRegion {
+                region_id,
+                slug: region.as_ref().and_then(|r| r.slug.clone()),
+                name: region.as_ref().and_then(|r| r.name.clone()),
             })
         })
     })

--- a/backend/lores-node-axum/src/local_apps/region_resolver.rs
+++ b/backend/lores-node-axum/src/local_apps/region_resolver.rs
@@ -1,10 +1,23 @@
-use lores_p2panda_server::{AppInstanceIds, ResolveRegionId, ResolveRegionIdError, ResolvedRegion};
+use lores_p2panda_server::{AppInstanceIds, NodeInfo, ResolveNodeInfo, ResolveRegionId, ResolveRegionIdError, ResolvedRegion};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use tracing::warn;
 
 use crate::data::node_data::local_apps_repo::LocalAppsRepo;
+use crate::data::projections_read::region_nodes::RegionNodesReadRepo;
 use crate::data::projections_read::regions::RegionsReadRepo;
+
+async fn resolve_region_id_hex(pool: &SqlitePool, ids: &AppInstanceIds) -> Result<String, ResolveRegionIdError> {
+    let row = LocalAppsRepo::init()
+        .find(pool, &ids.app_id, &Some(ids.instance_id.clone()))
+        .await
+        .map_err(|e| {
+            warn!("[region_resolver] database error: {e}");
+            ResolveRegionIdError::Internal
+        })?;
+
+    row.and_then(|app| app.bound_to_region_id).ok_or(ResolveRegionIdError::NotFound)
+}
 
 /// Returns a [`lores_p2panda_server::ResolveRegionId`] callback that looks up
 /// the `bound_to_region_id` for a given app/instance pair from the node_data
@@ -14,15 +27,7 @@ pub fn make_region_resolver(node_data_pool: SqlitePool, projections_pool: Sqlite
         let node_data_pool = node_data_pool.clone();
         let projections_pool = projections_pool.clone();
         Box::pin(async move {
-            let row = LocalAppsRepo::init()
-                .find(&node_data_pool, &ids.app_id, &Some(ids.instance_id.clone()))
-                .await
-                .map_err(|e| {
-                    warn!("[region_resolver] database error: {e}");
-                    ResolveRegionIdError::Internal
-                })?;
-
-            let region_id_hex = row.and_then(|app| app.bound_to_region_id).ok_or(ResolveRegionIdError::NotFound)?;
+            let region_id_hex = resolve_region_id_hex(&node_data_pool, &ids).await?;
 
             let region_id = lores_p2panda::RegionId::from_hex(&region_id_hex).map_err(|_| {
                 warn!(
@@ -44,6 +49,33 @@ pub fn make_region_resolver(node_data_pool: SqlitePool, projections_pool: Sqlite
                 region_id,
                 slug: region.as_ref().and_then(|r| r.slug.clone()),
                 name: region.as_ref().and_then(|r| r.name.clone()),
+            })
+        })
+    })
+}
+
+/// Returns a [`lores_p2panda_server::ResolveNodeInfo`] callback that looks up
+/// node metadata from the projections database, scoped to the caller's region.
+pub fn make_node_resolver(node_data_pool: SqlitePool, projections_pool: SqlitePool) -> ResolveNodeInfo {
+    Arc::new(move |ids: AppInstanceIds, node_id: String| {
+        let node_data_pool = node_data_pool.clone();
+        let projections_pool = projections_pool.clone();
+        Box::pin(async move {
+            let region_id_hex = resolve_region_id_hex(&node_data_pool, &ids).await?;
+
+            let node = RegionNodesReadRepo::init()
+                .find_by_keys(&projections_pool, &node_id, &region_id_hex)
+                .await
+                .map_err(|e| {
+                    warn!("[node_resolver] projections database error: {e}");
+                    ResolveRegionIdError::Internal
+                })?
+                .ok_or(ResolveRegionIdError::NotFound)?;
+
+            Ok(NodeInfo {
+                node_id: node.node_id,
+                name: node.name,
+                domain_on_internet: node.domain_on_internet,
             })
         })
     })

--- a/backend/lores-node-axum/src/local_apps/region_resolver.rs
+++ b/backend/lores-node-axum/src/local_apps/region_resolver.rs
@@ -37,13 +37,10 @@ pub fn make_region_resolver(node_data_pool: SqlitePool, projections_pool: Sqlite
                 ResolveRegionIdError::Internal
             })?;
 
-            let region = RegionsReadRepo::init()
-                .find(&projections_pool, &region_id_hex)
-                .await
-                .map_err(|e| {
-                    warn!("[region_resolver] projections database error: {e}");
-                    ResolveRegionIdError::Internal
-                })?;
+            let region = RegionsReadRepo::init().find(&projections_pool, &region_id_hex).await.map_err(|e| {
+                warn!("[region_resolver] projections database error: {e}");
+                ResolveRegionIdError::Internal
+            })?;
 
             Ok(ResolvedRegion {
                 region_id,

--- a/backend/lores-node-axum/src/main.rs
+++ b/backend/lores-node-axum/src/main.rs
@@ -107,7 +107,7 @@ async fn main() {
     let grpc_addr = format!("0.0.0.0:{}", grpc_port).parse().expect("valid gRPC bind address");
     let panda_service = {
         let on_instance_seen = local_apps::app_instances::make_instance_seen_callback(node_data_pool.clone());
-        let resolve_region_id = local_apps::region_resolver::make_region_resolver(node_data_pool.clone());
+        let resolve_region_id = local_apps::region_resolver::make_region_resolver(node_data_pool.clone(), projections_pool.clone());
         lores_p2panda_server::PandaService::new(
             panda_container.node_arc(),
             node_data_pool.clone(),

--- a/backend/lores-node-axum/src/main.rs
+++ b/backend/lores-node-axum/src/main.rs
@@ -108,12 +108,14 @@ async fn main() {
     let panda_service = {
         let on_instance_seen = local_apps::app_instances::make_instance_seen_callback(node_data_pool.clone());
         let resolve_region_id = local_apps::region_resolver::make_region_resolver(node_data_pool.clone(), projections_pool.clone());
+        let resolve_node_info = local_apps::region_resolver::make_node_resolver(node_data_pool.clone(), projections_pool.clone());
         lores_p2panda_server::PandaService::new(
             panda_container.node_arc(),
             node_data_pool.clone(),
             None,
             on_instance_seen,
             resolve_region_id,
+            resolve_node_info,
         )
         .await
         .expect("Failed to initialise PandaService")

--- a/backend/lores-p2panda-client/Cargo.toml
+++ b/backend/lores-p2panda-client/Cargo.toml
@@ -14,7 +14,9 @@ publish = true
 license-file = "LICENSE.txt"
 
 [dependencies]
+hex.workspace = true
 prost = "0.14"
+serde = { workspace = true, optional = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 tonic = "0.14"
@@ -22,3 +24,6 @@ tonic-prost = "0.14"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
+
+[features]
+serde = ["dep:serde"]

--- a/backend/lores-p2panda-client/proto/panda.proto
+++ b/backend/lores-p2panda-client/proto/panda.proto
@@ -67,11 +67,17 @@ message InfoRequest {
   string instance_id = 2;
 }
 
+message RegionInfo {
+  // 32-byte region identifier.
+  bytes region_id = 1;
+  optional string slug = 2;
+  optional string name = 3;
+}
+
 message InfoResponse {
   // 32-byte p2panda public key of this node.
   bytes node_id = 1;
-  // 32-byte region identifier assigned to this app instance.
-  bytes region_id = 2;
+  RegionInfo region = 2;
 }
 
 

--- a/backend/lores-p2panda-client/proto/panda.proto
+++ b/backend/lores-p2panda-client/proto/panda.proto
@@ -63,12 +63,15 @@ message OperationEvent {
 }
 
 message InfoRequest {
-  string instance_id = 1;
+  string app_id = 1;
+  string instance_id = 2;
 }
 
 message InfoResponse {
   // 32-byte p2panda public key of this node.
   bytes node_id = 1;
+  // 32-byte region identifier assigned to this app instance.
+  bytes region_id = 2;
 }
 
 

--- a/backend/lores-p2panda-client/proto/panda.proto
+++ b/backend/lores-p2panda-client/proto/panda.proto
@@ -17,6 +17,9 @@ service Panda {
   // Returns information about the connected server node.
   rpc Info(InfoRequest) returns (InfoResponse);
 
+  // Returns information about a node in the same region.
+  rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
+
 }
 
 message PublishRequest {
@@ -80,4 +83,16 @@ message InfoResponse {
   RegionInfo region = 2;
 }
 
+message GetNodeRequest {
+  string app_id = 1;
+  string instance_id = 2;
+  // Hex-encoded node public key to look up.
+  string node_id = 3;
+}
+
+message GetNodeResponse {
+  string node_id = 1;
+  optional string name = 2;
+  optional string domain_on_internet = 3;
+}
 

--- a/backend/lores-p2panda-client/src/lib.rs
+++ b/backend/lores-p2panda-client/src/lib.rs
@@ -91,7 +91,15 @@ impl fmt::Display for RegionId {
 #[derive(Debug, Clone)]
 pub struct InfoResult {
     pub node_id: NodeId,
+    pub region: RegionInfo,
+}
+
+/// Region identity and metadata returned by [`PandaClient::info`].
+#[derive(Debug, Clone)]
+pub struct RegionInfo {
     pub region_id: RegionId,
+    pub slug: Option<String>,
+    pub name: Option<String>,
 }
 
 /// Result of a successful publish, containing both the assigned operation id
@@ -228,13 +236,20 @@ impl PandaClient {
                 instance_id: instance_id.into(),
             })
             .await
-            .map(|r| {
-                let r = r.into_inner();
-                InfoResult {
-                    node_id: NodeId(r.node_id),
-                    region_id: RegionId(r.region_id),
-                }
-            })
             .map_err(PandaError::from)
+            .and_then(|r| {
+                let r = r.into_inner();
+                let region = r.region.ok_or_else(|| {
+                    PandaError::Rpc(tonic::Status::internal("server returned info response without region"))
+                })?;
+                Ok(InfoResult {
+                    node_id: NodeId(r.node_id),
+                    region: RegionInfo {
+                        region_id: RegionId(region.region_id),
+                        slug: region.slug,
+                        name: region.name,
+                    },
+                })
+            })
     }
 }

--- a/backend/lores-p2panda-client/src/lib.rs
+++ b/backend/lores-p2panda-client/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use tonic::transport::Channel;
 
 pub mod proto {
@@ -8,25 +9,89 @@ use proto::{InfoRequest, OperationEvent, PublishRequest, SubscribeRequest, panda
 use tonic::{Code, Response, Status, Streaming};
 
 /// 32-byte p2panda operation hash returned by a successful publish.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OperationId(pub Vec<u8>);
 
 impl OperationId {
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+
     /// Returns the bytes if non-empty, or `None` for an absent value.
     pub fn into_non_empty(self) -> Option<Vec<u8>> {
         if self.0.is_empty() { None } else { Some(self.0) }
     }
 }
 
+impl fmt::Debug for OperationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "OperationId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for OperationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
 /// 32-byte p2panda public key identifying a node.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeId(pub Vec<u8>);
 
 impl NodeId {
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+
     /// Returns the bytes if non-empty, or `None` for an absent value.
     pub fn into_non_empty(self) -> Option<Vec<u8>> {
         if self.0.is_empty() { None } else { Some(self.0) }
     }
+}
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+/// 32-byte region identifier.
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RegionId(pub Vec<u8>);
+
+impl RegionId {
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+}
+
+impl fmt::Debug for RegionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RegionId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for RegionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+/// Result of a successful [`PandaClient::info`] call.
+#[derive(Debug, Clone)]
+pub struct InfoResult {
+    pub node_id: NodeId,
+    pub region_id: RegionId,
 }
 
 /// Result of a successful publish, containing both the assigned operation id
@@ -156,13 +221,20 @@ impl PandaClient {
     }
 
     /// Retrieve information about the connected server node.
-    pub async fn info(&mut self, instance_id: impl Into<String>) -> Result<NodeId, PandaError> {
+    pub async fn info(&mut self, app_id: impl Into<String>, instance_id: impl Into<String>) -> Result<InfoResult, PandaError> {
         self.inner
             .info(InfoRequest {
+                app_id: app_id.into(),
                 instance_id: instance_id.into(),
             })
             .await
-            .map(|r| NodeId(r.into_inner().node_id))
+            .map(|r| {
+                let r = r.into_inner();
+                InfoResult {
+                    node_id: NodeId(r.node_id),
+                    region_id: RegionId(r.region_id),
+                }
+            })
             .map_err(PandaError::from)
     }
 }

--- a/backend/lores-p2panda-client/src/lib.rs
+++ b/backend/lores-p2panda-client/src/lib.rs
@@ -5,7 +5,7 @@ pub mod proto {
     tonic::include_proto!("lores.panda.v2");
 }
 
-use proto::{InfoRequest, OperationEvent, PublishRequest, SubscribeRequest, panda_client::PandaClient as TonicPandaClient};
+use proto::{GetNodeRequest, InfoRequest, OperationEvent, PublishRequest, SubscribeRequest, panda_client::PandaClient as TonicPandaClient};
 use tonic::{Code, Response, Status, Streaming};
 
 /// 32-byte p2panda operation hash returned by a successful publish.
@@ -87,6 +87,14 @@ impl fmt::Display for RegionId {
     }
 }
 
+/// Node identity and metadata returned by [`PandaClient::get_node`].
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub node_id: String,
+    pub name: Option<String>,
+    pub domain_on_internet: Option<String>,
+}
+
 /// Result of a successful [`PandaClient::info`] call.
 #[derive(Debug, Clone)]
 pub struct InfoResult {
@@ -141,6 +149,26 @@ impl From<Status> for PandaError {
         }
     }
 }
+
+/// Errors returned by [`PandaClient::get_node`].
+#[derive(Debug)]
+pub enum GetNodeError {
+    /// The requested node was not found in the region.
+    NodeNotFound(String),
+    /// Any other error (including region not bound).
+    Other(PandaError),
+}
+
+impl std::fmt::Display for GetNodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetNodeError::NodeNotFound(msg) => write!(f, "{msg}"),
+            GetNodeError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for GetNodeError {}
 
 /// Client for the lores-p2panda-server gRPC API.
 pub struct PandaClient {
@@ -250,6 +278,34 @@ impl PandaClient {
                         name: region.name,
                     },
                 })
+            })
+    }
+
+    /// Retrieve information about a node in the same region.
+    pub async fn get_node(
+        &mut self,
+        app_id: impl Into<String>,
+        instance_id: impl Into<String>,
+        node_id: impl Into<String>,
+    ) -> Result<NodeInfo, GetNodeError> {
+        self.inner
+            .get_node(GetNodeRequest {
+                app_id: app_id.into(),
+                instance_id: instance_id.into(),
+                node_id: node_id.into(),
+            })
+            .await
+            .map(|r| {
+                let r = r.into_inner();
+                NodeInfo {
+                    node_id: r.node_id,
+                    name: r.name,
+                    domain_on_internet: r.domain_on_internet,
+                }
+            })
+            .map_err(|s| match s.code() {
+                Code::NotFound => GetNodeError::NodeNotFound(s.message().to_string()),
+                _ => GetNodeError::Other(PandaError::from(s)),
             })
     }
 }

--- a/backend/lores-p2panda-client/src/lib.rs
+++ b/backend/lores-p2panda-client/src/lib.rs
@@ -267,9 +267,9 @@ impl PandaClient {
             .map_err(PandaError::from)
             .and_then(|r| {
                 let r = r.into_inner();
-                let region = r.region.ok_or_else(|| {
-                    PandaError::Rpc(tonic::Status::internal("server returned info response without region"))
-                })?;
+                let region = r
+                    .region
+                    .ok_or_else(|| PandaError::Rpc(tonic::Status::internal("server returned info response without region")))?;
                 Ok(InfoResult {
                     node_id: NodeId(r.node_id),
                     region: RegionInfo {

--- a/backend/lores-p2panda-dev-server/src/service.rs
+++ b/backend/lores-p2panda-dev-server/src/service.rs
@@ -12,7 +12,10 @@ use tracing::{info, warn};
 
 use sha2::{Digest, Sha256};
 
-use crate::proto::{panda_server::Panda, InfoRequest, InfoResponse, OperationEvent, PublishRequest, PublishResponse, SubscribeRequest};
+use crate::proto::{
+    panda_server::Panda, GetNodeRequest, GetNodeResponse, InfoRequest, InfoResponse, OperationEvent, PublishRequest, PublishResponse,
+    SubscribeRequest,
+};
 
 /// In-memory dev server for the lores-p2panda gRPC API.
 ///
@@ -26,6 +29,8 @@ pub struct DevPandaService {
     topics: Arc<RwLock<HashMap<String, broadcast::Sender<OperationEvent>>>>,
     /// Stable author id (32-byte, incrementing) assigned per `instance_id`.
     authors: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+    /// Reverse map from hex node_id to instance_id, used by get_node.
+    node_names: Arc<RwLock<HashMap<String, String>>>,
     /// Monotonically increasing counter used to synthesise `operation_id`s.
     counter: Arc<AtomicU64>,
     /// Monotonically increasing counter used to assign author ids.
@@ -37,6 +42,7 @@ impl DevPandaService {
         Self {
             topics: Arc::new(RwLock::new(HashMap::new())),
             authors: Arc::new(RwLock::new(HashMap::new())),
+            node_names: Arc::new(RwLock::new(HashMap::new())),
             counter: Arc::new(AtomicU64::new(1)),
             author_counter: Arc::new(AtomicU64::new(1)),
         }
@@ -123,6 +129,7 @@ impl Panda for DevPandaService {
 
         let operation_id = self.next_operation_id();
         let node_id = dummy_node_id(&req.instance_id);
+        self.node_names.write().await.insert(hex::encode(&node_id), req.instance_id.clone());
 
         let event = OperationEvent {
             topic_id: topic_id_from_app_id(&req.app_id),
@@ -166,6 +173,7 @@ impl Panda for DevPandaService {
     async fn info(&self, _request: Request<InfoRequest>) -> Result<Response<InfoResponse>, Status> {
         let req = _request.into_inner();
         let node_id = dummy_node_id(&req.instance_id);
+        self.node_names.write().await.insert(hex::encode(&node_id), req.instance_id.clone());
 
         info!(instance_id = %req.instance_id, node_id = %hex::encode(&node_id), "info");
 
@@ -176,6 +184,16 @@ impl Panda for DevPandaService {
                 slug: Some("dev-region".to_string()),
                 name: Some("Dev Region".to_string()),
             }),
+        }))
+    }
+
+    async fn get_node(&self, request: Request<GetNodeRequest>) -> Result<Response<GetNodeResponse>, Status> {
+        let req = request.into_inner();
+        let name = self.node_names.read().await.get(&req.node_id).cloned();
+        Ok(Response::new(GetNodeResponse {
+            node_id: req.node_id,
+            name,
+            domain_on_internet: None,
         }))
     }
 }

--- a/backend/lores-p2panda-dev-server/src/service.rs
+++ b/backend/lores-p2panda-dev-server/src/service.rs
@@ -88,6 +88,10 @@ fn dummy_node_id(instance_id: &str) -> Vec<u8> {
     Sha256::digest(instance_id.as_bytes()).to_vec()
 }
 
+fn dummy_region_id(app_id: &str) -> Vec<u8> {
+    Sha256::digest(app_id.as_bytes()).to_vec()
+}
+
 fn topic_id_from_app_id(app_id: &str) -> Vec<u8> {
     let mut topic_id = vec![0u8; 32];
     let bytes = app_id.as_bytes();
@@ -160,11 +164,12 @@ impl Panda for DevPandaService {
     }
 
     async fn info(&self, _request: Request<InfoRequest>) -> Result<Response<InfoResponse>, Status> {
-        let instance_id = _request.into_inner().instance_id;
-        let node_id = dummy_node_id(&instance_id);
+        let req = _request.into_inner();
+        let node_id = dummy_node_id(&req.instance_id);
+        let region_id = dummy_region_id(&req.app_id);
 
-        info!(instance_id = %instance_id, node_id = %hex::encode(&node_id), "info");
+        info!(instance_id = %req.instance_id, node_id = %hex::encode(&node_id), "info");
 
-        Ok(Response::new(InfoResponse { node_id }))
+        Ok(Response::new(InfoResponse { node_id, region_id }))
     }
 }

--- a/backend/lores-p2panda-dev-server/src/service.rs
+++ b/backend/lores-p2panda-dev-server/src/service.rs
@@ -27,45 +27,19 @@ pub struct DevPandaService {
     /// One broadcast channel per `app_id`. All subscribers to the same app
     /// share the same channel so they see each other's operations.
     topics: Arc<RwLock<HashMap<String, broadcast::Sender<OperationEvent>>>>,
-    /// Stable author id (32-byte, incrementing) assigned per `instance_id`.
-    authors: Arc<RwLock<HashMap<String, Vec<u8>>>>,
     /// Reverse map from hex node_id to instance_id, used by get_node.
     node_names: Arc<RwLock<HashMap<String, String>>>,
     /// Monotonically increasing counter used to synthesise `operation_id`s.
     counter: Arc<AtomicU64>,
-    /// Monotonically increasing counter used to assign author ids.
-    author_counter: Arc<AtomicU64>,
 }
 
 impl DevPandaService {
     pub fn new() -> Self {
         Self {
             topics: Arc::new(RwLock::new(HashMap::new())),
-            authors: Arc::new(RwLock::new(HashMap::new())),
             node_names: Arc::new(RwLock::new(HashMap::new())),
             counter: Arc::new(AtomicU64::new(1)),
-            author_counter: Arc::new(AtomicU64::new(1)),
         }
-    }
-
-    async fn author_id_for(&self, instance_id: &str) -> Vec<u8> {
-        {
-            let authors = self.authors.read().await;
-            if let Some(id) = authors.get(instance_id) {
-                return id.clone();
-            }
-        }
-        let mut authors = self.authors.write().await;
-        // Re-check after acquiring write lock.
-        authors
-            .entry(instance_id.to_string())
-            .or_insert_with(|| {
-                let n = self.author_counter.fetch_add(1, Ordering::SeqCst);
-                let mut bytes = vec![0u8; 32];
-                bytes[24..32].copy_from_slice(&n.to_be_bytes());
-                bytes
-            })
-            .clone()
     }
 
     async fn topic_tx(&self, app_id: &str) -> broadcast::Sender<OperationEvent> {
@@ -120,7 +94,7 @@ impl Panda for DevPandaService {
 
         let tx = self.topic_tx(&req.app_id).await;
 
-        let author = self.author_id_for(&req.instance_id).await;
+        let author = dummy_node_id(&req.instance_id);
 
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -190,6 +164,9 @@ impl Panda for DevPandaService {
     async fn get_node(&self, request: Request<GetNodeRequest>) -> Result<Response<GetNodeResponse>, Status> {
         let req = request.into_inner();
         let name = self.node_names.read().await.get(&req.node_id).cloned();
+
+        info!(node_id = %req.node_id, name = ?name, "get_node");
+
         Ok(Response::new(GetNodeResponse {
             node_id: req.node_id,
             name,

--- a/backend/lores-p2panda-dev-server/src/service.rs
+++ b/backend/lores-p2panda-dev-server/src/service.rs
@@ -166,10 +166,16 @@ impl Panda for DevPandaService {
     async fn info(&self, _request: Request<InfoRequest>) -> Result<Response<InfoResponse>, Status> {
         let req = _request.into_inner();
         let node_id = dummy_node_id(&req.instance_id);
-        let region_id = dummy_region_id(&req.app_id);
 
         info!(instance_id = %req.instance_id, node_id = %hex::encode(&node_id), "info");
 
-        Ok(Response::new(InfoResponse { node_id, region_id }))
+        Ok(Response::new(InfoResponse {
+            node_id,
+            region: Some(crate::proto::RegionInfo {
+                region_id: dummy_region_id(&req.app_id),
+                slug: Some("dev-region".to_string()),
+                name: Some("Dev Region".to_string()),
+            }),
+        }))
     }
 }

--- a/backend/lores-p2panda-server/src/lib.rs
+++ b/backend/lores-p2panda-server/src/lib.rs
@@ -40,8 +40,7 @@ pub mod proto {
 }
 
 use proto::{
-    GetNodeRequest, GetNodeResponse, InfoRequest, InfoResponse, OperationEvent, PublishRequest,
-    PublishResponse, SubscribeRequest,
+    GetNodeRequest, GetNodeResponse, InfoRequest, InfoResponse, OperationEvent, PublishRequest, PublishResponse, SubscribeRequest,
     panda_server::{Panda, PandaServer},
 };
 

--- a/backend/lores-p2panda-server/src/lib.rs
+++ b/backend/lores-p2panda-server/src/lib.rs
@@ -250,14 +250,23 @@ impl Panda for PandaService {
         Ok(Response::new(Box::pin(stream)))
     }
 
-    async fn info(&self, _request: Request<InfoRequest>) -> Result<Response<InfoResponse>, Status> {
+    async fn info(&self, request: Request<InfoRequest>) -> Result<Response<InfoResponse>, Status> {
+        let req = request.into_inner();
         let node_lock = self.node.lock().await;
         let node = node_lock
             .as_ref()
             .ok_or_else(|| Status::unavailable("p2panda node is not yet started"))?;
         let node_id = node.public_key.as_bytes().to_vec();
         drop(node_lock);
-        Ok(Response::new(InfoResponse { node_id }))
+        let ids = AppInstanceIds {
+            app_id: req.app_id,
+            instance_id: req.instance_id,
+        };
+        let region_id = (self.resolve_region_id)(ids.clone())
+            .await
+            .map_err(|e| resolve_region_error_to_status(e, &ids))
+            .map(|r| <[u8; 32]>::from(r).to_vec())?;
+        Ok(Response::new(InfoResponse { node_id, region_id }))
     }
 }
 

--- a/backend/lores-p2panda-server/src/lib.rs
+++ b/backend/lores-p2panda-server/src/lib.rs
@@ -44,13 +44,21 @@ use proto::{
     panda_server::{Panda, PandaServer},
 };
 
-/// Error returned by the [`ResolveRegionId`] callback.
+/// Error returned by the [`ResolveRegion`] callback.
 #[derive(Debug)]
 pub enum ResolveRegionIdError {
     /// No region is bound to the given app/instance.
     NotFound,
     /// The stored binding is corrupt or otherwise unusable.
     Internal,
+}
+
+/// Region identity and metadata returned by the [`ResolveRegion`] callback.
+#[derive(Debug, Clone)]
+pub struct ResolvedRegion {
+    pub region_id: RegionId,
+    pub slug: Option<String>,
+    pub name: Option<String>,
 }
 
 /// Identifies the app and instance making a gRPC request.
@@ -60,11 +68,11 @@ pub struct AppInstanceIds {
     pub instance_id: String,
 }
 
-/// Async callback type for resolving a [`RegionId`] from an [`AppInstanceIds`].
+/// Async callback that resolves region identity and metadata for an app instance.
 /// The owner (e.g. `lores-node-axum`) supplies this when constructing
 /// [`PandaService`].
 pub type ResolveRegionId =
-    Arc<dyn Fn(AppInstanceIds) -> Pin<Box<dyn Future<Output = Result<RegionId, ResolveRegionIdError>> + Send>> + Send + Sync>;
+    Arc<dyn Fn(AppInstanceIds) -> Pin<Box<dyn Future<Output = Result<ResolvedRegion, ResolveRegionIdError>> + Send>> + Send + Sync>;
 
 /// gRPC service that exposes [`PandaNode`] publish and subscribe over the
 /// network.
@@ -150,7 +158,7 @@ impl Panda for PandaService {
             instance_id: req.instance_id,
         };
 
-        let region_id = (self.resolve_region_id)(ids.clone())
+        let region = (self.resolve_region_id)(ids.clone())
             .await
             .map_err(|e| resolve_region_error_to_status(e, &ids))?;
 
@@ -161,7 +169,7 @@ impl Panda for PandaService {
             .clone();
         drop(node_lock);
 
-        let region_app_topic = RegionAppTopic::new(region_id, ids.app_id);
+        let region_app_topic = RegionAppTopic::new(region.region_id, ids.app_id);
 
         info!(
             "[publish] region={} app_id={} payload_bytes={}",
@@ -214,7 +222,7 @@ impl Panda for PandaService {
             instance_id: req.instance_id,
         };
 
-        let region_id = (self.resolve_region_id)(ids.clone())
+        let region = (self.resolve_region_id)(ids.clone())
             .await
             .map_err(|e| resolve_region_error_to_status(e, &ids))?;
 
@@ -225,7 +233,7 @@ impl Panda for PandaService {
             .clone();
         drop(node_lock);
 
-        let region_app_topic = RegionAppTopic::new(region_id, ids.app_id);
+        let region_app_topic = RegionAppTopic::new(region.region_id, ids.app_id);
 
         info!(
             "[subscribe] region={} app_id={}",
@@ -262,11 +270,17 @@ impl Panda for PandaService {
             app_id: req.app_id,
             instance_id: req.instance_id,
         };
-        let region_id = (self.resolve_region_id)(ids.clone())
+        let region = (self.resolve_region_id)(ids.clone())
             .await
-            .map_err(|e| resolve_region_error_to_status(e, &ids))
-            .map(|r| <[u8; 32]>::from(r).to_vec())?;
-        Ok(Response::new(InfoResponse { node_id, region_id }))
+            .map_err(|e| resolve_region_error_to_status(e, &ids))?;
+        Ok(Response::new(InfoResponse {
+            node_id,
+            region: Some(proto::RegionInfo {
+                region_id: <[u8; 32]>::from(region.region_id).to_vec(),
+                slug: region.slug,
+                name: region.name,
+            }),
+        }))
     }
 }
 

--- a/backend/lores-p2panda-server/src/lib.rs
+++ b/backend/lores-p2panda-server/src/lib.rs
@@ -40,7 +40,8 @@ pub mod proto {
 }
 
 use proto::{
-    InfoRequest, InfoResponse, OperationEvent, PublishRequest, PublishResponse, SubscribeRequest,
+    GetNodeRequest, GetNodeResponse, InfoRequest, InfoResponse, OperationEvent, PublishRequest,
+    PublishResponse, SubscribeRequest,
     panda_server::{Panda, PandaServer},
 };
 
@@ -74,6 +75,20 @@ pub struct AppInstanceIds {
 pub type ResolveRegionId =
     Arc<dyn Fn(AppInstanceIds) -> Pin<Box<dyn Future<Output = Result<ResolvedRegion, ResolveRegionIdError>> + Send>> + Send + Sync>;
 
+/// Node information returned by the [`ResolveNodeInfo`] callback.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub node_id: String,
+    pub name: Option<String>,
+    pub domain_on_internet: Option<String>,
+}
+
+/// Async callback that looks up node metadata within a region.
+/// Returns `None` when the node exists but has no enrichment data.
+/// Returns `Err(ResolveRegionIdError::NotFound)` when the node is not in the region.
+pub type ResolveNodeInfo =
+    Arc<dyn Fn(AppInstanceIds, String) -> Pin<Box<dyn Future<Output = Result<NodeInfo, ResolveRegionIdError>> + Send>> + Send + Sync>;
+
 /// gRPC service that exposes [`PandaNode`] publish and subscribe over the
 /// network.
 ///
@@ -89,6 +104,7 @@ pub struct PandaService {
     idempotency: IdempotencyStore,
     instance_notifier: InstanceNotifier,
     resolve_region_id: ResolveRegionId,
+    resolve_node_info: ResolveNodeInfo,
 }
 
 impl PandaService {
@@ -98,6 +114,7 @@ impl PandaService {
         idempotency_config: Option<IdempotencyConfig>,
         on_instance_seen: Arc<dyn Fn(String, String) + Send + Sync>,
         resolve_region_id: ResolveRegionId,
+        resolve_node_info: ResolveNodeInfo,
     ) -> Result<Self, sqlx::Error> {
         let config = idempotency_config.unwrap_or_default();
         let idempotency = IdempotencyStore::new(db, config.cleanup_frequency, config.retention).await?;
@@ -107,6 +124,7 @@ impl PandaService {
             idempotency,
             instance_notifier: InstanceNotifier::new(on_instance_seen),
             resolve_region_id,
+            resolve_node_info,
         })
     }
 
@@ -280,6 +298,22 @@ impl Panda for PandaService {
                 slug: region.slug,
                 name: region.name,
             }),
+        }))
+    }
+
+    async fn get_node(&self, request: Request<GetNodeRequest>) -> Result<Response<GetNodeResponse>, Status> {
+        let req = request.into_inner();
+        let ids = AppInstanceIds {
+            app_id: req.app_id,
+            instance_id: req.instance_id,
+        };
+        let info = (self.resolve_node_info)(ids.clone(), req.node_id.clone())
+            .await
+            .map_err(|e| resolve_region_error_to_status(e, &ids))?;
+        Ok(Response::new(GetNodeResponse {
+            node_id: info.node_id,
+            name: info.name,
+            domain_on_internet: info.domain_on_internet,
         }))
     }
 }


### PR DESCRIPTION
Updated the gRPC API (breaking change) with region and node info, as this will be needed by apps.
In particular, the kiwix app needs this info to name the nodes where the website archive you want is located.